### PR TITLE
Prioritze email over domain for request phase

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniauth-osso (0.1.8.pre)
+    omniauth-osso (0.2.0)
       omniauth (~> 2.0.1)
       omniauth-oauth2 (>= 1.6, < 1.8)
 

--- a/lib/omniauth-osso/version.rb
+++ b/lib/omniauth-osso/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module Osso
-    VERSION = '0.1.8'
+    VERSION = '0.2.0'
   end
 end

--- a/lib/omniauth/strategies/osso.rb
+++ b/lib/omniauth/strategies/osso.rb
@@ -88,7 +88,7 @@ module OmniAuth
       def user_param
         return @user_param if defined?(@user_param)
 
-        params = request.params.reject{|k,v| v.empty? }
+        params = request.params.reject { |_k, v| v.empty? }
 
         @user_param = {}
         @user_param = { domain: request.params['domain'] } if params['domain']

--- a/lib/omniauth/strategies/osso.rb
+++ b/lib/omniauth/strategies/osso.rb
@@ -88,9 +88,11 @@ module OmniAuth
       def user_param
         return @user_param if defined?(@user_param)
 
+        params = request.params.reject{|k,v| v.empty? }
+
         @user_param = {}
-        @user_param = { domain: request.params['domain'] } if request.params['domain']
-        @user_param = { email: request.params['email'] } if request.params['email']
+        @user_param = { domain: request.params['domain'] } if params['domain']
+        @user_param = { email: request.params['email'] } if params['email']
 
         @user_param
       end

--- a/lib/omniauth/strategies/osso.rb
+++ b/lib/omniauth/strategies/osso.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'omniauth-oauth2'
-require 'pry'
+
 module OmniAuth
   module Strategies
     # The main source for the Osso Omniauth Strategy

--- a/lib/omniauth/strategies/osso.rb
+++ b/lib/omniauth/strategies/osso.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'omniauth-oauth2'
-
+require 'pry'
 module OmniAuth
   module Strategies
     # The main source for the Osso Omniauth Strategy
@@ -88,10 +88,11 @@ module OmniAuth
       def user_param
         return @user_param if defined?(@user_param)
 
-        @user_param = {
-          domain: request.params['domain'],
-          email: request.params['email']
-        }.compact
+        @user_param = {}
+        @user_param = { domain: request.params['domain'] } if request.params['domain']
+        @user_param = { email: request.params['email'] } if request.params['email']
+
+        @user_param
       end
     end
   end

--- a/spec/omniauth/strategies/osso_spec.rb
+++ b/spec/omniauth/strategies/osso_spec.rb
@@ -84,7 +84,8 @@ describe OmniAuth::Strategies::Osso do
       instance = subject.new('abc', 'def')
       instance.env = {}
       allow(instance).to receive(:request) do
-        double('Request', params: { 'email' => 'user@example.com', 'domain' => 'example.com' }, scheme: 'https', url: url)
+        double('Request', params: { 'email' => 'user@example.com', 'domain' => 'example.com' }, scheme: 'https',
+                          url: url)
       end
 
       expect(instance.request_params[:email]).to eq('user@example.com')
@@ -95,7 +96,7 @@ describe OmniAuth::Strategies::Osso do
       instance = subject.new('abc', 'def')
       instance.env = {}
       allow(instance).to receive(:request) do
-        double('Request', params: { }, scheme: 'https', url: url)
+        double('Request', params: {}, scheme: 'https', url: url)
       end
 
       expect(instance.request_params.keys).to eq([:redirect_uri])

--- a/spec/omniauth/strategies/osso_spec.rb
+++ b/spec/omniauth/strategies/osso_spec.rb
@@ -70,13 +70,35 @@ describe OmniAuth::Strategies::Osso do
       expect(instance.request_params[:domain]).to eq('example.com')
     end
 
-    it 'includes email when an email address is passed as an authorize option' do
+    it 'includes email passed as a request param' do
       instance = subject.new('abc', 'def')
       instance.env = {}
       allow(instance).to receive(:request) do
         double('Request', params: { 'email' => 'user@example.com' }, scheme: 'https', url: url)
       end
+
       expect(instance.request_params[:email]).to eq('user@example.com')
+    end
+
+    it 'only includes email as a request param when both keys are provided' do
+      instance = subject.new('abc', 'def')
+      instance.env = {}
+      allow(instance).to receive(:request) do
+        double('Request', params: { 'email' => 'user@example.com', 'domain' => 'example.com' }, scheme: 'https', url: url)
+      end
+
+      expect(instance.request_params[:email]).to eq('user@example.com')
+      expect(instance.request_params.keys).to_not include(:domain)
+    end
+
+    it 'only includes redirect_uri as a request param if neither email or domain are provided' do
+      instance = subject.new('abc', 'def')
+      instance.env = {}
+      allow(instance).to receive(:request) do
+        double('Request', params: { }, scheme: 'https', url: url)
+      end
+
+      expect(instance.request_params.keys).to eq([:redirect_uri])
     end
   end
 

--- a/spec/omniauth/strategies/osso_spec.rb
+++ b/spec/omniauth/strategies/osso_spec.rb
@@ -92,6 +92,18 @@ describe OmniAuth::Strategies::Osso do
       expect(instance.request_params.keys).to_not include(:domain)
     end
 
+    it 'domain as a request param when email key is a blank string' do
+      instance = subject.new('abc', 'def')
+      instance.env = {}
+      allow(instance).to receive(:request) do
+        double('Request', params: { 'email' => '', 'domain' => 'example.com' }, scheme: 'https',
+                          url: url)
+      end
+
+      expect(instance.request_params[:domain]).to eq('example.com')
+      expect(instance.request_params.keys).to_not include(:email)
+    end
+
     it 'only includes redirect_uri as a request param if neither email or domain are provided' do
       instance = subject.new('abc', 'def')
       instance.env = {}


### PR DESCRIPTION
Missed one thing in the last update, and this is a minor breaking change. 

We now prioritize email over domain if both are included in params to /auth/osso, and properly handle when none are included, or included as blank strings